### PR TITLE
Fix crash after sent all

### DIFF
--- a/src/pages/network/evm/Token.jsx
+++ b/src/pages/network/evm/Token.jsx
@@ -211,6 +211,12 @@ const Token = () => {
     estimateGas();
   }, [recipient, amount, token]);
 
+  useEffect(() => {
+    if (selectedTokenAddress && !token && !loading) {
+      selectToken("");
+    }
+  }, [selectedTokenAddress, token, loading, selectToken]);
+
   const onSuccess = async (txn) => {
     setConfirming(false);
     setTransaction(null);
@@ -234,9 +240,18 @@ const Token = () => {
       <MinedTransaction
         txnHash={txnHash}
         txnLink={account.linkOfTransaction(txnHash)}
-        back={() => setTxnHash("")}
+        back={() => {
+          setTxnHash("");
+          if (!token) {
+            selectToken("");
+          }
+        }}
       />
     );
+  }
+
+  if (!token) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
# Fix crash after sent `All`

## Description

After sending`All` token, token list will be empty, and disappeared.
So in that case, user will be redirected to token list home.

## Changes


