### PR TITLE
Add `Terms of Use` document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
-
-
-
-
-https://github.com/user-attachments/assets/796195c9-fc26-4e35-b9ea-e4cac95bef18
-
-
-
 # mybucks.online
 
 ## Summary
+
+This is a source repository of [app.mybucks.online](https://app.mybucks.online).
 
 Mybucks.online is a **password-only, self-custodial and browser-based cryptocurrency wallet** built with [React.js](https://react.dev). It generates a private key from your password and passcode using an industry-standard, verified **one-way hash function**. Your private key forms your account, allowing you to transfer, receive, and hold your crypto assets permanently.
 
@@ -105,7 +99,7 @@ The core components responsible for hash and private-key generation have been ex
 npm install @mybucks.online/core
 ```
 
-## Transfer Ownership
+## Transfer Ownership 🎁🎁🎁
 
 You can transfer all your holdings to family or friends in a few seconds by sharing your password only.  
 Send this short note to your friend in a private channel.
@@ -116,6 +110,8 @@ mybucks.online / DemoAccount5& : 112324
 
 And you can even transfer wallet itself by using a URL:  
 https://app.mybucks.online/?wallet=VWnsSGRGVtb0FjY291bnQ1JgIxMTIzMjQCb3B0aW1pc20=_wNovT
+
+This might sound complicated, but it's actually quite simple: you're sending someone your cryptocurrency along with the wallet itself. Think of it like putting $5 or $10 cash in an envelope with a gift card - they receive both the money and the card.
 
 You can extract this link in the `Backup` menu.  
 This feature allows you to transfer cryptocurrency `without asking recipient's address`.
@@ -153,45 +149,16 @@ yarn dev
 
 ## Production Environment
 
-The project uses `Github Pages` and `Github Actions` for deployment and is connected to a custom domain.
-You can easily verify releases, deployments, and domain configuration:
+The project is deployed via GitHub Pages and GitHub Actions. You can verify the deployment and DNS configuration:
 
 - [Actions](https://github.com/mybucks-online/app/actions)
 - [Releases](https://github.com/mybucks-online/app/releases)
-- [.github/workflows/main-pipeline.yml](https://github.com/mybucks-online/app/blob/master/.github/workflows/main-pipeline.yml)
-
-To check DNS settings:
-
-```bash
-nslookup
-> app.mybucks.online
-Server:		127.0.0.53
-Address:	127.0.0.53#53
-
-Non-authoritative answer:
-app.mybucks.online	canonical name = mybucks-online.github.io.
-Name:	mybucks-online.github.io
-
-~~~
-```
-
-```bash
-dig app.mybucks.online
-
-;; ANSWER SECTION:
-app.mybucks.online.	5	IN	CNAME	https://mybucks-online.github.io.
-https://mybucks-online.github.io. 5 IN	A	185.199.110.153
-https://mybucks-online.github.io. 5 IN	A	185.199.109.153
-https://mybucks-online.github.io. 5 IN	A	185.199.108.153
-https://mybucks-online.github.io. 5 IN	A	185.199.111.153
-
-~~~
-```
+- DNS: `app.mybucks.online` → `mybucks-online.github.io`
 
 # Quick Links
 
+- App: https://app.mybucks.online
 - Website: https://mybucks.online
-- Wallet: https://app.mybucks.online
 - Docs: https://docs.mybucks.online
 - Github: https://github.com/mybucks-online
 - Discord: https://discord.gg/RTHgTePKgP

--- a/TERMS_OF_USE.md
+++ b/TERMS_OF_USE.md
@@ -1,0 +1,197 @@
+# Terms of Use
+
+**Last Updated: January 2025**
+
+## 1. Acceptance of Terms
+
+By accessing or using Mybucks.online ("the Service", "we", "us", or "our"), you agree to be bound by these Terms of Use ("Terms"). If you do not agree to these Terms, you must not use the Service.
+
+## 2. Description of Service
+
+Mybucks.online is a browser-based, password-only, and self-custodial cryptocurrency wallet. The Service generates a private key from your password and passcode inputs using an industry-standard, verified one-way hash function (scrypt Key Derivation Function and keccak256). Your private key forms your account, allowing you to transfer, receive, and hold your crypto assets.
+
+### Key Features:
+- **Self-Custodial**: You maintain full control and custody of your private keys
+- **Browser-Based**: The Service fully runs on your browser side without using any storage or invoking any third-party APIs for key management
+- **No Storage**: Your private key is instantly generated from your password input, and whenever you close or refresh your browser, there is no footprint
+- **Password-Only**: Access to your wallet requires only your password and passcode
+
+## 3. Self-Custodial Nature and User Responsibility
+
+### 3.1 Self-Custodial Wallet
+You acknowledge and agree that:
+- You are solely responsible for the custody and security of your password, passcode, and private keys
+- We do not store, have access to, or can recover your password, passcode, or private keys
+- You are solely responsible for any transactions initiated from your wallet
+- Loss of your password or passcode will result in permanent loss of access to your wallet and any assets contained therein
+
+### 3.2 No Account Recovery
+**IMPORTANT**: There is no account recovery mechanism. If you lose your password or passcode, you will permanently lose access to your wallet and all assets. We cannot and will not assist in recovering lost credentials.
+
+### 3.3 Backup Responsibility
+You are solely responsible for:
+- Safely storing and backing up your password and passcode
+- Maintaining the confidentiality of your credentials
+- Ensuring you can access your wallet when needed
+
+## 4. Risks and Disclaimers
+
+### 4.1 Cryptocurrency Risks
+You acknowledge that:
+- Cryptocurrency transactions are irreversible
+- The value of cryptocurrencies is highly volatile and can result in significant losses
+- Cryptocurrency markets are unregulated and may be subject to manipulation
+- There is no guarantee that cryptocurrency will maintain its value or liquidity
+
+### 4.2 Technical Risks
+You understand and accept that:
+- The Service relies on blockchain networks that may experience congestion, forks, or other technical issues
+- Network fees may apply to transactions and can be significant
+- Smart contract interactions carry inherent risks
+- Browser-based applications may be subject to security vulnerabilities
+- You are responsible for ensuring your device and browser are secure and free from malware
+
+### 4.3 No Warranties
+THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+
+## 5. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL MYBUCKS.ONLINE, ITS DEVELOPERS, CONTRIBUTORS, OR AFFILIATES BE LIABLE FOR:
+- ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES
+- LOSS OF PROFITS, REVENUE, DATA, OR USE
+- LOSS OF CRYPTOCURRENCY ASSETS
+- UNAUTHORIZED ACCESS TO OR USE OF YOUR WALLET
+- ANY DAMAGES RESULTING FROM YOUR USE OR INABILITY TO USE THE SERVICE
+
+YOU ACKNOWLEDGE THAT YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK AND THAT YOU ARE SOLELY RESPONSIBLE FOR ANY LOSSES INCURRED.
+
+## 6. Prohibited Uses
+
+You agree not to:
+- Use the Service for any illegal purpose or in violation of any laws or regulations
+- Use the Service to engage in money laundering, terrorist financing, or other criminal activities
+- Attempt to gain unauthorized access to the Service or any related systems
+- Interfere with or disrupt the Service or servers
+- Use the Service in any manner that could damage, disable, or impair the Service
+- Reverse engineer, decompile, or disassemble any part of the Service (except as permitted by the MIT License)
+- Use automated systems or bots to access the Service without authorization
+
+## 7. Intellectual Property
+
+The Service is open-source software licensed under the MIT License. You may use, modify, and distribute the software in accordance with the terms of that license. However, the Mybucks.online name, logo, and branding are protected intellectual property.
+
+## 8. Privacy
+
+The Service is designed with privacy in mind:
+- No registration or personal information is required
+- No passwords, passcodes, or private keys are stored or transmitted to our servers
+- All key generation and wallet operations occur entirely in your browser
+- We do not track user activities within the wallet application
+- Analytics may be used on the landing page only (not within the wallet application)
+
+For more information, please refer to our Privacy Policy (if applicable).
+
+## 9. Service Availability and Modifications
+
+### 9.1 Availability
+We do not guarantee that the Service will be available at all times or that it will be free from errors, interruptions, or security vulnerabilities. The Service may be unavailable due to:
+- Maintenance or updates
+- Technical issues
+- Network problems
+- Force majeure events
+
+### 9.2 Modifications
+We reserve the right to:
+- Modify, suspend, or discontinue the Service at any time
+- Update these Terms at any time
+- Change the Service's features or functionality
+
+We will make reasonable efforts to notify users of significant changes, but you are responsible for reviewing these Terms periodically.
+
+## 10. Third-Party Services and Links
+
+The Service may integrate with or link to third-party services, including:
+- Blockchain networks (Ethereum, Tron, etc.)
+- Blockchain explorers
+- Token lists (e.g., Uniswap default token list)
+- External APIs (Infura, Moralis, Trongrid)
+
+### 10.1 Token Filtering
+
+Token balances displayed in the Service are filtered based on the Uniswap default token list. This filtering mechanism helps to hide spam tokens and improve user experience by showing only verified tokens. 
+
+**Important Notes:**
+- Not all tokens in your wallet may be displayed if they are not included in the filtering criteria
+- The filtering conditions may be updated or modified at any time without prior notice
+- Tokens that are filtered out are still in your wallet and accessible through other means (e.g., direct contract interaction)
+- We do not guarantee that all legitimate tokens will be displayed, nor that all spam tokens will be filtered
+
+### 10.2 Third-Party Service Disclaimers
+
+We are not responsible for:
+- The availability, accuracy, or reliability of third-party services
+- Any losses resulting from the use of third-party services
+- The content, privacy practices, or terms of third-party services
+- The accuracy or completeness of token lists used for filtering
+
+## 11. Compliance and Legal Requirements
+
+You are solely responsible for:
+- Complying with all applicable laws and regulations in your jurisdiction
+- Determining whether your use of the Service is legal in your jurisdiction
+- Paying any taxes that may be due on transactions or holdings
+- Complying with anti-money laundering (AML) and know-your-customer (KYC) requirements if applicable
+
+## 12. Indemnification
+
+You agree to indemnify, defend, and hold harmless Mybucks.online, its developers, contributors, and affiliates from any claims, damages, losses, liabilities, and expenses (including legal fees) arising from:
+- Your use of the Service
+- Your violation of these Terms
+- Your violation of any law or regulation
+- Your infringement of any rights of another party
+
+## 13. Service Discontinuation
+
+### 13.1 Service Availability
+Since the Service is a self-custodial, browser-based application with no user accounts or registration system, we cannot terminate or suspend individual user access. However, we reserve the right to:
+- Discontinue hosting the Service on our public domain at any time
+- Modify or remove the Service from public availability
+- Stop maintaining or updating the Service
+
+### 13.2 Your Right to Discontinue Use
+You may stop using the Service at any time. Since the Service operates entirely in your browser and does not store any data, simply closing your browser or not accessing the website constitutes discontinuing use.
+
+### 13.3 Open Source Nature
+The Service is open-source software licensed under the MIT License. If the public service is discontinued, you may continue to use the software by hosting it yourself or using community-maintained versions, subject to the MIT License terms.
+
+## 14. Governing Law and Dispute Resolution
+
+These Terms shall be governed by and construed in accordance with applicable laws. Any disputes arising from or relating to these Terms or the Service shall be resolved through appropriate legal channels.
+
+## 15. Severability
+
+If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.
+
+## 16. Entire Agreement
+
+These Terms constitute the entire agreement between you and Mybucks.online regarding the use of the Service and supersede all prior agreements and understandings.
+
+## 17. Contact Information
+
+If you have any questions about these Terms, please contact us through:
+- Website: https://mybucks.online
+- Documentation: https://docs.mybucks.online
+- GitHub: https://github.com/mybucks-online
+
+## 18. Acknowledgment
+
+BY USING THE SERVICE, YOU ACKNOWLEDGE THAT:
+- YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THESE TERMS
+- YOU UNDERSTAND THE RISKS ASSOCIATED WITH CRYPTOCURRENCY AND SELF-CUSTODIAL WALLETS
+- YOU ARE SOLELY RESPONSIBLE FOR THE SECURITY OF YOUR CREDENTIALS AND ASSETS
+- YOU WILL NOT HOLD MYBUCKS.ONLINE LIABLE FOR ANY LOSSES RESULTING FROM YOUR USE OF THE SERVICE
+
+---
+
+**IMPORTANT REMINDER**: This is a self-custodial wallet. You are solely responsible for your password, passcode, and private keys. We cannot recover your wallet if you lose your credentials. Use the Service at your own risk.
+

--- a/TERMS_OF_USE.md
+++ b/TERMS_OF_USE.md
@@ -1,6 +1,6 @@
 # Terms of Use
 
-**Last Updated: January 2025**
+**Last Updated: December 2025**
 
 ## 1. Acceptance of Terms
 

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -7,6 +7,7 @@ import Checkbox from "@mybucks/components/Checkbox";
 import { Box } from "@mybucks/components/Containers";
 import Input from "@mybucks/components/Input";
 import { Label } from "@mybucks/components/Label";
+import Link from "@mybucks/components/Link";
 import Modal from "@mybucks/components/Modal";
 import PasswordToggleIcon from "@mybucks/components/PasswordToggleIcon";
 import Progress from "@mybucks/components/Progress";
@@ -162,6 +163,35 @@ const TrustpilotWrapper = styled.div`
   margin-top: ${({ theme }) => theme.sizes.x2l};
 `;
 
+const TermsCheckboxWrapper = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: ${({ theme }) => theme.sizes.xs};
+  margin-bottom: ${({ theme }) => theme.sizes.xl};
+  margin-top: ${({ theme }) => theme.sizes.base};
+`;
+
+const TermsCheckboxInput = styled.input.attrs({
+  type: "checkbox",
+})`
+  margin-top: 0.25rem;
+  cursor: pointer;
+  flex-shrink: 0;
+`;
+
+const TermsCheckboxLabel = styled.label`
+  font-size: ${({ theme }) => theme.sizes.sm};
+  font-weight: ${({ theme }) => theme.weights.regular};
+  line-height: 140%;
+  color: ${({ theme }) => theme.colors.gray400};
+  user-select: none;
+  cursor: pointer;
+
+  a {
+    font-size: inherit;
+  }
+`;
+
 const SignIn = () => {
   const { setup } = useContext(StoreContext);
   const trustpilotWidgetRef = useRef(null);
@@ -178,6 +208,7 @@ const SignIn = () => {
   const [showPasscode, setShowPasscode] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(false);
   const [passcodeFocused, setPasscodeFocused] = useState(false);
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
 
   const hasMinLengthPassword = useMemo(
     () => password.length >= PASSWORD_MIN_LENGTH,
@@ -205,8 +236,9 @@ const SignIn = () => {
       !hasUppercase ||
       !hasNumbers ||
       !hasSymbol ||
-      !hasValidPasscodeLength,
-    [password, passcode, disabled, hasMinLengthPassword, hasLowercase, hasUppercase, hasNumbers, hasSymbol, hasValidPasscodeLength]
+      !hasValidPasscodeLength ||
+      !agreedToTerms,
+    [password, passcode, disabled, hasMinLengthPassword, hasLowercase, hasUppercase, hasNumbers, hasSymbol, hasValidPasscodeLength, agreedToTerms]
   );
 
   const unknownFact = useMemo(
@@ -365,6 +397,25 @@ const SignIn = () => {
               Passcode length: {PASSCODE_MIN_LENGTH}~{PASSCODE_MAX_LENGTH}
             </Checkbox>
           </Checkboxes>
+
+          <TermsCheckboxWrapper>
+            <TermsCheckboxInput
+              id="terms-checkbox"
+              checked={agreedToTerms}
+              onChange={(e) => setAgreedToTerms(e.target.checked)}
+              disabled={disabled}
+            />
+            <TermsCheckboxLabel htmlFor="terms-checkbox">
+              I agree to the{" "}
+              <Link
+                href="https://docs.mybucks.online/more/terms-of-use"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Terms of Use
+              </Link>
+            </TermsCheckboxLabel>
+          </TermsCheckboxWrapper>
 
           <Button onClick={onSubmit} disabled={hasInvalidInput} $size="block">
             Open


### PR DESCRIPTION
# Add Terms of Use document

## Description
Adds a Terms of Use document to the repository to clarify the service's self-custodial nature and set user expectations.

## Changes

Added TERMS_OF_USE.md covering:
- Service description (browser-based, self-custodial, password-only wallet)
- User responsibilities (password/private key security, no account recovery)
- Risk disclaimers (cryptocurrency volatility, technical risks)
- Liability limitations
- Token filtering (Uniswap default token list)
- Service discontinuation (no individual access control)
- Privacy information
- Prohibited uses
