### PR TITLE
add CSP header

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <link rel="shortcut icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
+    <!-- Content Security Policy -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' https://widget.trustpilot.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src 'self' https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org; frame-src https://widget.trustpilot.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+    />
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://mybucks.online" />
@@ -47,7 +52,7 @@
     />
 
     <!-- TrustBox script -->
-    <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
+    <script type="text/javascript" src="https://widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
     <!-- End TrustBox script -->
 
     <title>

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,9 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    assetsInlineLimit: 0,
+  },
   plugins: [
     react(),
     nodePolyfills({


### PR DESCRIPTION
# Content-Security-Policy header

## Add `meta` tag into index.html for CSP header
default-src 'self';
script-src 'self' https://widget.trustpilot.com;
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io;
font-src 'self' data:;
connect-src 'self' https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org;
frame-src https://widget.trustpilot.com;
object-src 'none';
base-uri 'self';
form-action 'self';
frame-ancestors 'none';
upgrade-insecure-requests;

## Update Vite config to prevent inline script

## Changes


