### PR TITLE
Rename password → passphrase and passcode → PIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This is a source repository of [app.mybucks.online](https://app.mybucks.online).
 
-[Mybucks.online](https://mybucks.online) is a **seedless, disposable crypto wallet** designed for **speed and convenience**. It generates a private key from your password and passcode using an industry-standard, verified **one-way hash function**. Your private key forms your account, allowing you to transfer, receive, and hold your crypto assets instantly.
+[Mybucks.online](https://mybucks.online) is a **seedless, disposable crypto wallet** designed for **speed and convenience**. It generates a private key from your **passphrase and PIN** using an industry-standard, verified **one-way hash function**. Your private key forms your account, allowing you to transfer, receive, and hold your crypto assets instantly.
 
-As a hash function, the **Scrypt** Key Derivation Function (KDF) increases the computational effort required to crack passwords, effectively delaying **brute-force** attacks and making them impractical.
+As a hash function, the **Scrypt** Key Derivation Function (KDF) increases the computational effort required to crack credentials, effectively delaying **brute-force** attacks and making them impractical.
 
-It fully runs on your **browser side** without using any storage or invoking any 3rd-party APIs for key management. It instantly generates your private key from your password input, and whenever you close or refresh, there is **no footprint**. This absolutely protects your privacy.
+It fully runs on your **browser side** without using any storage or invoking any 3rd-party APIs for key management. It instantly generates your private key from your credentials input, and whenever you close or refresh, there is **no footprint**. This absolutely protects your privacy.
 
 ### Zero Footprint  
 - No servers, no databases, no storage and no tracking.
@@ -17,7 +17,7 @@ It fully runs on your **browser side** without using any storage or invoking any
 ### Fast and Easy
 - No app installs, no browser extensions, no registration and no KYC.
 - You can create or open your wallet in seconds - all you need is your browser.
-- Password is easier to handle and remember than seed phrases
+- Passphrase and PIN are easier to handle and remember than seed phrases
 
 ### 1-Click Gifting
 - Stop asking your friends for their wallet addresses.
@@ -28,10 +28,10 @@ It fully runs on your **browser side** without using any storage or invoking any
 ## How to Use
 
 1. Visit [app.mybucks.online](https://app.mybucks.online).
-2. Input your password and passcode.  
+2. Input your credentials.  
   Test credentials:  
-    password: **DemoAccount5&**  
-    passcode: **112324**
+    passphrase: **DemoAccount5&**  
+    PIN: **112324**
 3. Click `Open`.
 
 (This process is the same for both initial opening and all subsequent uses.)
@@ -51,7 +51,7 @@ The **Scrypt** and **Keccak256** hash functions turn your credentials into a pri
 
 ## Generate the private key
 
-This demonstrates how to generate a private key from your `password` and `passcode` and helps you understand the process.
+This demonstrates how to generate a private key from your `passphrase` and `PIN` and helps you understand the process.
 
 ```javascript
 import { Buffer } from "buffer";
@@ -65,16 +65,16 @@ const HASH_OPTIONS = {
   keyLen: 64,
 };
 
-// password: at least 12 characters user input, lowercase, uppercase, digits, and special characters
-// passcode: at least 6 characters
-async function generatePrivateKey(password, passcode) {
-  const salt = `${password.slice(-4)}${passcode}`
+// passphrase: at least 12 characters user input, lowercase, uppercase, digits, and special characters
+// PIN: at least 6 characters
+async function generatePrivateKey(passphrase, pin) {
+  const salt = `${passphrase.slice(-4)}${pin}`
 
-  const passwordBuffer = Buffer.from(password);
+  const passphraseBuffer = Buffer.from(passphrase);
   const saltBuffer = Buffer.from(salt);
 
   const hashBuffer = await scrypt(
-    passwordBuffer,
+    passphraseBuffer,
     saltBuffer,
     HASH_OPTIONS.N,
     HASH_OPTIONS.r,

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src 'self' https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
     />
 
     <!-- Canonical URL -->

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="Mybucks.online | Password-only, self-custodial crypto wallet"
+      content="Mybucks.online | Seedless, Disposable Crypto Wallet with 1-Click URL"
     />
 
     <meta
-      content="No seed phrases, no register, decentralized crypto wallet. Your password is your account."
+      content="Seedless, disposable crypto wallet. No servers, no database, no app installs. Just your browser-based seedless crypto wallet. Send crypto by 1-click URL for airdrops, marketing campaigns, and instant onboarding."
       property="og:description"
     />
     <meta property="og:image" content="/logo-72x72.png" />
@@ -36,23 +36,23 @@
     <meta name="twitter:image" content="/logo-72x72.png" />
     <meta
       name="twitter:description"
-      content="No seed phrases, no register, decentralized crypto wallet. Your password is your account."
+      content="Seedless, disposable crypto wallet. No servers, no database, no app installs. Just your browser-based seedless crypto wallet. Send crypto by 1-click URL for airdrops, marketing campaigns, and instant onboarding."
     />
 
     <!-- Meta description for search engines -->
     <meta
       name="description"
-      content="No seed phrases, no register, decentralized crypto wallet. Your password is your account."
+      content="Seedless, disposable crypto wallet. No servers, no database, no app installs. Send crypto by 1-click URL. Perfect for airdrops, marketing campaigns, and instant user onboarding. Browser-based and decentralized."
     />
 
     <!-- Optional: Meta keywords (less important nowadays) -->
     <meta
       name="keywords"
-      content="cryptocurrency wallet, password-only, password-only wallet, self-custodial, wallet, crypto wallet, coin wallet, ether wallet, Ethereum wallet, digital wallet, tron, trx, usdt, pepe, doge, arbitrum, optimism, bnb chain, polygon, avalanche, safest wallet, convenient wallet, secure crypto wallet, online wallet, temp wallet, crypto gift, gift wallet, blockchains, mybucks, mybucks.online"
+      content="seedless wallet, disposable crypto wallet, 1-click crypto, browser-based wallet, crypto airdrop, marketing campaigns, instant onboarding, no seed phrase wallet, self-custodial wallet, crypto gift, gift wallet, airdrop wallet, disposable wallet, temporary wallet, crypto URL wallet, Layer3 rewards, crypto marketing, Ethereum wallet, arbitrum, optimism, bnb chain, polygon, avalanche, tron, usdt, decentralized wallet, online wallet, mybucks, mybucks.online"
     />
 
     <title>
-      Mybucks.online | Password-only, self-custodial crypto wallet
+      Mybucks.online | Seedless, Disposable Crypto Wallet with 1-Click URL
     </title>
   </head>
   <body>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "mybucks.online | Password-only crypto wallet",
+  "name": "Mybucks.online | Seedless, Disposable Crypto Wallet with 1-Click URL",
   "short_name": "mybucks.online",
   "icons": [
     {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -173,9 +173,25 @@ function App() {
       <Footer>
         <h5>&copy; 2026 Mybucks.online MIT Licensed</h5>
 
-        <a href="https://codesandbox.io/p/sandbox/mybucks-online-key-generation-sandbox-lt53c3" target="_blank">
-          Verify Key Logic
-        </a>
+        <nav>
+          <ul>
+            <li>
+              <a href="https://docs.mybucks.online/more/terms-of-use" target="_blank">
+                Terms of Use
+              </a>
+            </li>
+            <li>
+              <a href="https://docs.mybucks.online/more/security-audits" target="_blank">
+                Security Audits
+              </a>
+            </li>
+            <li>
+              <a href="https://codesandbox.io/p/sandbox/mybucks-online-key-generation-sandbox-lt53c3" target="_blank">
+                Play on Sandbox
+              </a>
+            </li>
+          </ul>
+        </nav>
 
         <nav>
           <ul>

--- a/src/components/ConfirmPinModal.jsx
+++ b/src/components/ConfirmPinModal.jsx
@@ -8,9 +8,9 @@ import Modal from "@mybucks/components/Modal";
 import { H3 } from "@mybucks/components/Texts";
 import { StoreContext } from "@mybucks/contexts/Store";
 import {
-  PASSCODE_MAX_LENGTH,
-  PASSCODE_MAX_TRY,
-  PASSCODE_MIN_LENGTH,
+  PIN_MAX_LENGTH,
+  PIN_MAX_TRY,
+  PIN_MIN_LENGTH,
 } from "@mybucks/lib/conf";
 
 const Wrap = styled.div`
@@ -40,7 +40,7 @@ const ConfirmPinModal = ({ show, onSuccess, onFailed }) => {
   const { pin } = useContext(StoreContext);
 
   const confirmPin = () => {
-    if (value.length < PASSCODE_MIN_LENGTH) {
+    if (value.length < PIN_MIN_LENGTH) {
       return;
     }
 
@@ -48,7 +48,7 @@ const ConfirmPinModal = ({ show, onSuccess, onFailed }) => {
 
     if (pin !== value) {
       setCounter(counter + 1);
-      if (counter + 1 >= PASSCODE_MAX_TRY) {
+      if (counter + 1 >= PIN_MAX_TRY) {
         toast("Wrong PIN!");
         onFailed();
       } else {
@@ -91,8 +91,8 @@ const ConfirmPinModal = ({ show, onSuccess, onFailed }) => {
         <Input
           type="password"
           placeholder="PIN"
-          minLength={PASSCODE_MIN_LENGTH}
-          maxLength={PASSCODE_MAX_LENGTH}
+          minLength={PIN_MIN_LENGTH}
+          maxLength={PIN_MAX_LENGTH}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={onKeyDown}
@@ -101,7 +101,7 @@ const ConfirmPinModal = ({ show, onSuccess, onFailed }) => {
         {invalid && <InvalidPin>Wrong PIN!</InvalidPin>}
         <Button
           onClick={confirmPin}
-          disabled={value.length < PASSCODE_MIN_LENGTH}
+          disabled={value.length < PIN_MIN_LENGTH}
         >
           Confirm
         </Button>

--- a/src/components/ConfirmPinModal.jsx
+++ b/src/components/ConfirmPinModal.jsx
@@ -25,7 +25,7 @@ const Title = styled(H3)`
   text-align: center;
 `;
 
-const InvalidPasscode = styled.div`
+const InvalidPin = styled.div`
   color: ${({ theme }) => theme.colors.error};
   font-weight: ${({ theme }) => theme.weights.base};
   font-size: ${({ theme }) => theme.sizes.xs};
@@ -33,23 +33,23 @@ const InvalidPasscode = styled.div`
   margin-bottom: ${({ theme }) => theme.sizes.xs};
 `;
 
-const ConfirmPasscodeModal = ({ show, onSuccess, onFailed }) => {
+const ConfirmPinModal = ({ show, onSuccess, onFailed }) => {
   const [counter, setCounter] = useState(0);
   const [value, setValue] = useState("");
   const [invalid, setInvalid] = useState(false);
-  const { passcode } = useContext(StoreContext);
+  const { pin } = useContext(StoreContext);
 
-  const confirmPasscode = () => {
+  const confirmPin = () => {
     if (value.length < PASSCODE_MIN_LENGTH) {
       return;
     }
 
-    setInvalid(passcode !== value);
+    setInvalid(pin !== value);
 
-    if (passcode !== value) {
+    if (pin !== value) {
       setCounter(counter + 1);
       if (counter + 1 >= PASSCODE_MAX_TRY) {
-        toast("Wrong passcode!");
+        toast("Wrong PIN!");
         onFailed();
       } else {
         return;
@@ -74,7 +74,7 @@ const ConfirmPasscodeModal = ({ show, onSuccess, onFailed }) => {
     setInvalid(false);
 
     if (e.key === "Enter") {
-      confirmPasscode();
+      confirmPin();
     }
   };
 
@@ -87,10 +87,10 @@ const ConfirmPasscodeModal = ({ show, onSuccess, onFailed }) => {
       width="20rem"
     >
       <Wrap>
-        <Title>Confirm Passcode</Title>
+        <Title>Confirm PIN</Title>
         <Input
           type="password"
-          placeholder="Passcode"
+          placeholder="PIN"
           minLength={PASSCODE_MIN_LENGTH}
           maxLength={PASSCODE_MAX_LENGTH}
           value={value}
@@ -98,9 +98,9 @@ const ConfirmPasscodeModal = ({ show, onSuccess, onFailed }) => {
           onKeyDown={onKeyDown}
           onPaste={(e) => e.preventDefault()}
         />
-        {invalid && <InvalidPasscode>Wrong passcode!</InvalidPasscode>}
+        {invalid && <InvalidPin>Wrong PIN!</InvalidPin>}
         <Button
-          onClick={confirmPasscode}
+          onClick={confirmPin}
           disabled={value.length < PASSCODE_MIN_LENGTH}
         >
           Confirm
@@ -110,4 +110,4 @@ const ConfirmPasscodeModal = ({ show, onSuccess, onFailed }) => {
   );
 };
 
-export default ConfirmPasscodeModal;
+export default ConfirmPinModal;

--- a/src/contexts/Store.jsx
+++ b/src/contexts/Store.jsx
@@ -11,8 +11,8 @@ import {
 
 export const StoreContext = createContext({
   connectivity: true,
-  password: "",
-  passcode: "",
+  passphrase: "",
+  pin: "",
   hash: "",
   setup: () => {},
   reset: () => {},
@@ -49,8 +49,8 @@ export const StoreContext = createContext({
 const StoreProvider = ({ children }) => {
   const [connectivity, setConnectivity] = useState(true);
   // key parts
-  const [password, setPassword] = useState("");
-  const [passcode, setPasscode] = useState("");
+  const [passphrase, setPassphrase] = useState("");
+  const [pin, setPin] = useState("");
   const [hash, setHash] = useState("");
 
   // theme related
@@ -145,8 +145,8 @@ const StoreProvider = ({ children }) => {
   }, [selectedTokenAddress]);
 
   const reset = () => {
-    setPassword("");
-    setPasscode("");
+    setPassphrase("");
+    setPin("");
     setHash("");
 
     setNetwork(DEFAULT_NETWORK);
@@ -166,8 +166,8 @@ const StoreProvider = ({ children }) => {
   };
 
   const setup = (pw, pc, hsh, nw, cid) => {
-    setPassword(pw);
-    setPasscode(pc);
+    setPassphrase(pw);
+    setPin(pc);
     setHash(hsh);
 
     if (nw) {
@@ -211,8 +211,8 @@ const StoreProvider = ({ children }) => {
     <StoreContext.Provider
       value={{
         connectivity,
-        password,
-        passcode,
+        passphrase,
+        pin,
         hash,
         reset,
         setup,

--- a/src/lib/conf.js
+++ b/src/lib/conf.js
@@ -121,7 +121,7 @@ export const LOADING_PLACEHOLDER = "-----";
 export const UNKNOWN_FACTS = [
   "Each credential creates a unique account.",
   "It runs only in your browser.",
-  "It never stores or transmits your password.",
+  "It never stores or transmits your credentials.",
   "Your account's origin remains anonymous.",
   "There's no reset or recovery option.",
 ];

--- a/src/lib/conf.js
+++ b/src/lib/conf.js
@@ -1,9 +1,9 @@
-export const PASSWORD_MIN_LENGTH = 12;
-export const PASSWORD_MAX_LENGTH = 128;
-export const PASSCODE_MIN_LENGTH = 6;
-export const PASSCODE_MAX_LENGTH = 16;
+export const PASSPHRASE_MIN_LENGTH = 12;
+export const PASSPHRASE_MAX_LENGTH = 128;
+export const PIN_MIN_LENGTH = 6;
+export const PIN_MAX_LENGTH = 16;
 
-export const PASSCODE_MAX_TRY = 3;
+export const PIN_MAX_TRY = 3;
 
 export const NETWORK = Object.freeze({
   EVM: "ethereum",
@@ -128,5 +128,5 @@ export const UNKNOWN_FACTS = [
 
 export const WALLET_URL_PARAM = "wallet";
 
-export const TEST_PASSWORD = "DemoAccount5&";
-export const TEST_PASSCODE = "112324";
+export const TEST_PASSPHRASE = "DemoAccount5&";
+export const TEST_PIN = "112324";

--- a/src/pages/Menu/index.jsx
+++ b/src/pages/Menu/index.jsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 
 import { BackIcon } from "@mybucks/assets/icons";
 import BaseButton from "@mybucks/components/Button";
-import ConfirmPasscodeModal from "@mybucks/components/ConfirmPasscodeModal";
+import ConfirmPinModal from "@mybucks/components/ConfirmPinModal";
 import { Box as BaseBox, Container } from "@mybucks/components/Containers";
 import { H3 } from "@mybucks/components/Texts";
 import { StoreContext } from "@mybucks/contexts/Store";
@@ -130,7 +130,7 @@ const Menu = () => {
         </Box>
       </Container>
 
-      <ConfirmPasscodeModal
+      <ConfirmPinModal
         show={confirmPin}
         onFailed={() => setConfirmPin(false)}
         onSuccess={onConfirmedPin}

--- a/src/pages/Menu/index.jsx
+++ b/src/pages/Menu/index.jsx
@@ -52,14 +52,14 @@ const QRCodeWrapper = styled.div`
   display: inline-block;
 `;
 
-const BACKUP_PASSWORD = 1;
+const BACKUP_CREDENTIALS = 1;
 const BACKUP_PRIVATE_KEY = 2;
 const BACKUP_TRANSFER_LINK = 3;
 
 const Menu = () => {
-  const [confirmPasscode, setConfirmPasscode] = useState(false);
+  const [confirmPin, setConfirmPin] = useState(false);
   const [nextStep, setNextStep] = useState(0);
-  const { openMenu, account, password, passcode, network, chainId } =
+  const { openMenu, account, passphrase, pin, network, chainId } =
     useContext(StoreContext);
 
   const backupAddress = () => {
@@ -67,32 +67,32 @@ const Menu = () => {
     toast("Address copied into clipboard.");
   };
 
-  const onClickPassword = () => {
-    setNextStep(BACKUP_PASSWORD);
-    setConfirmPasscode(true);
+  const onClickCredentials = () => {
+    setNextStep(BACKUP_CREDENTIALS);
+    setConfirmPin(true);
   };
 
   const onClickPrivateKey = () => {
     setNextStep(BACKUP_PRIVATE_KEY);
-    setConfirmPasscode(true);
+    setConfirmPin(true);
   };
 
   const onClickGenerateLink = () => {
     setNextStep(BACKUP_TRANSFER_LINK);
-    setConfirmPasscode(true);
+    setConfirmPin(true);
   };
 
-  const onConfirmedPasscode = () => {
-    setConfirmPasscode(false);
-    if (nextStep === BACKUP_PASSWORD) {
-      copy(`${password} : ${passcode}`);
-      toast("Password copied into clipboard.");
+  const onConfirmedPin = () => {
+    setConfirmPin(false);
+    if (nextStep === BACKUP_CREDENTIALS) {
+      copy(`${passphrase} : ${pin}`);
+      toast("Credentials copied into clipboard.");
     } else if (nextStep === BACKUP_PRIVATE_KEY) {
       copy(account.signer);
       toast("Private key copied into clipboard.");
     } else if (nextStep === BACKUP_TRANSFER_LINK) {
       const networkName = findNetworkNameByChainId(network, chainId);
-      const link = generateToken(password, passcode, networkName);
+      const link = generateToken(passphrase, pin, networkName);
       copy(
         window.location.origin + window.location.pathname + "#wallet=" + link
       );
@@ -118,8 +118,8 @@ const Menu = () => {
 
           <Button onClick={backupAddress}>Address</Button>
 
-          <Button onClick={onClickPassword} $variant="danger">
-            Password
+          <Button onClick={onClickCredentials} $variant="danger">
+            Credentials
           </Button>
           <Button onClick={onClickPrivateKey} $variant="danger">
             Private Key
@@ -131,9 +131,9 @@ const Menu = () => {
       </Container>
 
       <ConfirmPasscodeModal
-        show={confirmPasscode}
-        onFailed={() => setConfirmPasscode(false)}
-        onSuccess={onConfirmedPasscode}
+        show={confirmPin}
+        onFailed={() => setConfirmPin(false)}
+        onSuccess={onConfirmedPin}
       />
     </>
   );

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -7,7 +7,6 @@ import Checkbox from "@mybucks/components/Checkbox";
 import { Box } from "@mybucks/components/Containers";
 import Input from "@mybucks/components/Input";
 import { Label } from "@mybucks/components/Label";
-import Link from "@mybucks/components/Link";
 import Modal from "@mybucks/components/Modal";
 import PasswordToggleIcon from "@mybucks/components/PasswordToggleIcon";
 import Progress from "@mybucks/components/Progress";
@@ -158,18 +157,6 @@ const ToggleButton = styled.button`
   }
 `;
 
-
-const KeyGenerationComment = styled.div`
-  text-align: left;
-  color: ${({ theme }) => theme.colors.gray200};
-  font-size: ${({ theme }) => theme.sizes.xs};
-  font-weight: ${({ theme }) => theme.weights.regular};
-  margin-bottom: ${({ theme }) => theme.sizes.base};
-
-  a {
-    font-size: inherit;
-  }
-`;
 
 const SignIn = () => {
   const { setup } = useContext(StoreContext);
@@ -362,18 +349,6 @@ const SignIn = () => {
               </ToggleButton>
             </PasswordInputWrapper>
           </div>
-
-          <KeyGenerationComment>
-            <span>Keys are generated locally using Scrypt. </span>
-
-            <Link
-              href="https://codesandbox.io/p/sandbox/mybucks-online-key-generation-sandbox-lt53c3"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Verify Key Logic
-            </Link>
-          </KeyGenerationComment>
 
           <Checkboxes>
             <Checkbox id="uppercase" value={hasUppercase}>

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -158,31 +158,6 @@ const ToggleButton = styled.button`
   }
 `;
 
-const TermsCheckboxWrapper = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: ${({ theme }) => theme.sizes.xs};
-`;
-
-const TermsCheckboxInput = styled.input.attrs({
-  type: "checkbox",
-})`
-  margin-top: 0.25rem;
-  cursor: pointer;
-  flex-shrink: 0;
-`;
-
-const TermsCheckboxLabel = styled.label`
-  font-size: ${({ theme }) => theme.sizes.sm};
-  font-weight: ${({ theme }) => theme.weights.regular};
-  color: ${({ theme }) => theme.colors.gray400};
-  user-select: none;
-  cursor: pointer;
-
-  a {
-    font-size: inherit;
-  }
-`;
 
 const KeyGenerationComment = styled.div`
   text-align: left;
@@ -211,7 +186,6 @@ const SignIn = () => {
   const [showPin, setShowPin] = useState(false);
   const [passphraseFocused, setPassphraseFocused] = useState(false);
   const [pinFocused, setPinFocused] = useState(false);
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
 
   const hasMinLengthPassphrase = useMemo(
     () => passphrase.length >= PASSPHRASE_MIN_LENGTH,
@@ -239,8 +213,7 @@ const SignIn = () => {
       !hasUppercase ||
       !hasNumbers ||
       !hasSymbol ||
-      !hasValidPinLength ||
-      !agreedToTerms,
+      !hasValidPinLength,
     [
       passphrase,
       pin,
@@ -251,7 +224,6 @@ const SignIn = () => {
       hasNumbers,
       hasSymbol,
       hasValidPinLength,
-      agreedToTerms,
     ]
   );
 
@@ -423,24 +395,6 @@ const SignIn = () => {
               PIN length: {PIN_MIN_LENGTH}~{PIN_MAX_LENGTH}
             </Checkbox>
 
-            <TermsCheckboxWrapper>
-              <TermsCheckboxInput
-                id="terms-checkbox"
-                checked={agreedToTerms}
-                onChange={(e) => setAgreedToTerms(e.target.checked)}
-                disabled={disabled}
-              />
-              <TermsCheckboxLabel htmlFor="terms-checkbox">
-                I agree to the{" "}
-                <Link
-                  href="https://docs.mybucks.online/more/terms-of-use"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Terms of Use
-                </Link>
-              </TermsCheckboxLabel>
-            </TermsCheckboxWrapper>
           </Checkboxes>
 
           <Button onClick={onSubmit} disabled={hasInvalidInput} $size="block">

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -199,58 +199,58 @@ const KeyGenerationComment = styled.div`
 const SignIn = () => {
   const { setup } = useContext(StoreContext);
 
-  const [password, setPassword] = useState(
+  const [passphrase, setPassphrase] = useState(
     import.meta.env.DEV ? TEST_PASSWORD : ""
   );
-  const [passcode, setPasscode] = useState(
+  const [pin, setPin] = useState(
     import.meta.env.DEV ? TEST_PASSCODE : ""
   );
   const [disabled, setDisabled] = useState(false);
   const [progress, setProgress] = useState(0);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showPasscode, setShowPasscode] = useState(false);
-  const [passwordFocused, setPasswordFocused] = useState(false);
-  const [passcodeFocused, setPasscodeFocused] = useState(false);
+  const [showPassphrase, setShowPassphrase] = useState(false);
+  const [showPin, setShowPin] = useState(false);
+  const [passphraseFocused, setPassphraseFocused] = useState(false);
+  const [pinFocused, setPinFocused] = useState(false);
   const [agreedToTerms, setAgreedToTerms] = useState(false);
 
-  const hasMinLengthPassword = useMemo(
-    () => password.length >= PASSWORD_MIN_LENGTH,
-    [password]
+  const hasMinLengthPassphrase = useMemo(
+    () => passphrase.length >= PASSWORD_MIN_LENGTH,
+    [passphrase]
   );
-  const hasLowercase = useMemo(() => /[a-z]/.test(password), [password]);
-  const hasUppercase = useMemo(() => /[A-Z]/.test(password), [password]);
-  const hasNumbers = useMemo(() => /\d/.test(password), [password]);
+  const hasLowercase = useMemo(() => /[a-z]/.test(passphrase), [passphrase]);
+  const hasUppercase = useMemo(() => /[A-Z]/.test(passphrase), [passphrase]);
+  const hasNumbers = useMemo(() => /\d/.test(passphrase), [passphrase]);
   const hasSymbol = useMemo(
-    () => /[ !"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(password),
-    [password]
+    () => /[ !"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(passphrase),
+    [passphrase]
   );
-  const hasValidPasscodeLength = useMemo(
-    () => passcode.length >= PASSCODE_MIN_LENGTH,
-    [passcode]
+  const hasValidPinLength = useMemo(
+    () => pin.length >= PASSCODE_MIN_LENGTH,
+    [pin]
   );
 
   const hasInvalidInput = useMemo(
     () =>
       disabled ||
-      !password ||
-      !passcode ||
-      !hasMinLengthPassword ||
+      !passphrase ||
+      !pin ||
+      !hasMinLengthPassphrase ||
       !hasLowercase ||
       !hasUppercase ||
       !hasNumbers ||
       !hasSymbol ||
-      !hasValidPasscodeLength ||
+      !hasValidPinLength ||
       !agreedToTerms,
     [
-      password,
-      passcode,
+      passphrase,
+      pin,
       disabled,
-      hasMinLengthPassword,
+      hasMinLengthPassphrase,
       hasLowercase,
       hasUppercase,
       hasNumbers,
       hasSymbol,
-      hasValidPasscodeLength,
+      hasValidPinLength,
       agreedToTerms,
     ]
   );
@@ -272,7 +272,7 @@ const SignIn = () => {
         return;
       }
 
-      // parse password, passcode, network name from "secret" param
+      // parse passphrase, PIN, network name from "secret" param
       const [pwd, pc, nn] = parseToken(secret);
       if (!pwd || !pc || !nn) {
         clearQueryParams();
@@ -299,10 +299,10 @@ const SignIn = () => {
 
   const onSubmit = async () => {
     setDisabled(true);
-    const hash = await generateHash(password, passcode, (p) =>
+    const hash = await generateHash(passphrase, pin, (p) =>
       setProgress(Math.floor(p * 100))
     );
-    setup(password, passcode, hash);
+    setup(passphrase, pin, hash);
     setDisabled(false);
   };
 
@@ -327,65 +327,65 @@ const SignIn = () => {
         <Box>
           <Title>Unlock your wallet</Title>
           <Caption>
-            Enter your password and passcode to open or create a wallet
+            Enter your credentials to open or create a wallet
           </Caption>
 
           <div>
-            <Label htmlFor="password">Password</Label>
+            <Label htmlFor="passphrase">Passphrase</Label>
             <PasswordInputWrapper>
               <Input
-                id="password"
-                type={showPassword ? "text" : "password"}
-                placeholder="Password"
+                id="passphrase"
+                type={showPassphrase ? "text" : "password"}
+                placeholder="Passphrase"
                 disabled={disabled}
-                value={password}
+                value={passphrase}
                 maxLength={PASSWORD_MAX_LENGTH}
-                onChange={(e) => setPassword(e.target.value)}
+                onChange={(e) => setPassphrase(e.target.value)}
                 onKeyDown={onKeyDown}
                 onPaste={(e) => e.preventDefault()}
-                onFocus={() => setPasswordFocused(true)}
-                onBlur={() => setPasswordFocused(false)}
+                onFocus={() => setPassphraseFocused(true)}
+                onBlur={() => setPassphraseFocused(false)}
               />
               <ToggleButton
                 type="button"
                 disabled={disabled}
-                onClick={() => setShowPassword(!showPassword)}
-                aria-label={showPassword ? "Hide password" : "Show password"}
+                onClick={() => setShowPassphrase(!showPassphrase)}
+                aria-label={showPassphrase ? "Hide passphrase" : "Show passphrase"}
               >
                 <PasswordToggleIcon
-                  show={showPassword}
-                  focused={passwordFocused}
+                  show={showPassphrase}
+                  focused={passphraseFocused}
                 />
               </ToggleButton>
             </PasswordInputWrapper>
           </div>
 
           <div>
-            <Label htmlFor="passcode">Passcode</Label>
+            <Label htmlFor="pin">PIN</Label>
             <PasswordInputWrapper>
               <Input
-                id="passcode"
-                type={showPasscode ? "text" : "password"}
-                placeholder="Passcode"
+                id="pin"
+                type={showPin ? "text" : "password"}
+                placeholder="PIN"
                 disabled={disabled}
-                value={passcode}
+                value={pin}
                 maxLength={PASSCODE_MAX_LENGTH}
-                onChange={(e) => setPasscode(e.target.value)}
+                onChange={(e) => setPin(e.target.value)}
                 onKeyDown={onKeyDown}
                 onPaste={(e) => e.preventDefault()}
                 autoComplete="off"
-                onFocus={() => setPasscodeFocused(true)}
-                onBlur={() => setPasscodeFocused(false)}
+                onFocus={() => setPinFocused(true)}
+                onBlur={() => setPinFocused(false)}
               />
               <ToggleButton
                 type="button"
                 disabled={disabled}
-                onClick={() => setShowPasscode(!showPasscode)}
-                aria-label={showPasscode ? "Hide passcode" : "Show passcode"}
+                onClick={() => setShowPin(!showPin)}
+                aria-label={showPin ? "Hide PIN" : "Show PIN"}
               >
                 <PasswordToggleIcon
-                  show={showPasscode}
-                  focused={passcodeFocused}
+                  show={showPin}
+                  focused={pinFocused}
                 />
               </ToggleButton>
             </PasswordInputWrapper>
@@ -416,11 +416,11 @@ const SignIn = () => {
             <Checkbox id="special" value={hasSymbol}>
               Symbol
             </Checkbox>
-            <Checkbox id="min-length" value={hasMinLengthPassword}>
-              Password length: {PASSWORD_MIN_LENGTH}~{PASSWORD_MAX_LENGTH}
+            <Checkbox id="min-length" value={hasMinLengthPassphrase}>
+              Passphrase length: {PASSWORD_MIN_LENGTH}~{PASSWORD_MAX_LENGTH}
             </Checkbox>
-            <Checkbox id="passcode-length" value={hasValidPasscodeLength}>
-              Passcode length: {PASSCODE_MIN_LENGTH}~{PASSCODE_MAX_LENGTH}
+            <Checkbox id="pin-length" value={hasValidPinLength}>
+              PIN length: {PASSCODE_MIN_LENGTH}~{PASSCODE_MAX_LENGTH}
             </Checkbox>
 
             <TermsCheckboxWrapper>

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -7,6 +7,7 @@ import Checkbox from "@mybucks/components/Checkbox";
 import { Box } from "@mybucks/components/Containers";
 import Input from "@mybucks/components/Input";
 import { Label } from "@mybucks/components/Label";
+import Link from "@mybucks/components/Link";
 import Modal from "@mybucks/components/Modal";
 import PasswordToggleIcon from "@mybucks/components/PasswordToggleIcon";
 import Progress from "@mybucks/components/Progress";
@@ -14,12 +15,12 @@ import { H1 } from "@mybucks/components/Texts";
 import { StoreContext } from "@mybucks/contexts/Store";
 import {
   findNetworkByName,
-  PIN_MAX_LENGTH,
-  PIN_MIN_LENGTH,
   PASSPHRASE_MAX_LENGTH,
   PASSPHRASE_MIN_LENGTH,
-  TEST_PIN,
+  PIN_MAX_LENGTH,
+  PIN_MIN_LENGTH,
   TEST_PASSPHRASE,
+  TEST_PIN,
   UNKNOWN_FACTS,
   WALLET_URL_PARAM,
 } from "@mybucks/lib/conf";
@@ -94,7 +95,7 @@ const Caption = styled.p`
 `;
 
 const Checkboxes = styled.div`
-  margin-block: ${({ theme }) => `${theme.sizes.base} ${theme.sizes.xl}`};
+  margin-block: ${({ theme }) => `${theme.sizes.base} ${theme.sizes.x3s}`};
   display: flex;
   flex-wrap: wrap;
   & > div {
@@ -157,6 +158,18 @@ const ToggleButton = styled.button`
   }
 `;
 
+
+const TermsNotice = styled.p`
+  text-align: left;
+  font-size: ${({ theme }) => theme.sizes.xs};
+  font-weight: ${({ theme }) => theme.weights.regular};
+  color: ${({ theme }) => theme.colors.gray200};
+  margin-bottom: ${({ theme }) => theme.sizes.base};
+
+  a {
+    font-size: inherit;
+  }
+`;
 
 const SignIn = () => {
   const { setup } = useContext(StoreContext);
@@ -371,6 +384,18 @@ const SignIn = () => {
             </Checkbox>
 
           </Checkboxes>
+
+          <TermsNotice>
+            By clicking Open, you agree to our{" "}
+            <Link
+              href="https://docs.mybucks.online/more/terms-of-use"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Terms of Use
+            </Link>
+            .
+          </TermsNotice>
 
           <Button onClick={onSubmit} disabled={hasInvalidInput} $size="block">
             Open

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -15,12 +15,12 @@ import { H1 } from "@mybucks/components/Texts";
 import { StoreContext } from "@mybucks/contexts/Store";
 import {
   findNetworkByName,
-  PASSCODE_MAX_LENGTH,
-  PASSCODE_MIN_LENGTH,
-  PASSWORD_MAX_LENGTH,
-  PASSWORD_MIN_LENGTH,
-  TEST_PASSCODE,
-  TEST_PASSWORD,
+  PIN_MAX_LENGTH,
+  PIN_MIN_LENGTH,
+  PASSPHRASE_MAX_LENGTH,
+  PASSPHRASE_MIN_LENGTH,
+  TEST_PIN,
+  TEST_PASSPHRASE,
   UNKNOWN_FACTS,
   WALLET_URL_PARAM,
 } from "@mybucks/lib/conf";
@@ -200,10 +200,10 @@ const SignIn = () => {
   const { setup } = useContext(StoreContext);
 
   const [passphrase, setPassphrase] = useState(
-    import.meta.env.DEV ? TEST_PASSWORD : ""
+    import.meta.env.DEV ? TEST_PASSPHRASE : ""
   );
   const [pin, setPin] = useState(
-    import.meta.env.DEV ? TEST_PASSCODE : ""
+    import.meta.env.DEV ? TEST_PIN : ""
   );
   const [disabled, setDisabled] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -214,7 +214,7 @@ const SignIn = () => {
   const [agreedToTerms, setAgreedToTerms] = useState(false);
 
   const hasMinLengthPassphrase = useMemo(
-    () => passphrase.length >= PASSWORD_MIN_LENGTH,
+    () => passphrase.length >= PASSPHRASE_MIN_LENGTH,
     [passphrase]
   );
   const hasLowercase = useMemo(() => /[a-z]/.test(passphrase), [passphrase]);
@@ -225,7 +225,7 @@ const SignIn = () => {
     [passphrase]
   );
   const hasValidPinLength = useMemo(
-    () => pin.length >= PASSCODE_MIN_LENGTH,
+    () => pin.length >= PIN_MIN_LENGTH,
     [pin]
   );
 
@@ -339,7 +339,7 @@ const SignIn = () => {
                 placeholder="My-1st-car-was-a-red-Ford-2005!"
                 disabled={disabled}
                 value={passphrase}
-                maxLength={PASSWORD_MAX_LENGTH}
+                maxLength={PASSPHRASE_MAX_LENGTH}
                 onChange={(e) => setPassphrase(e.target.value)}
                 onKeyDown={onKeyDown}
                 onPaste={(e) => e.preventDefault()}
@@ -369,7 +369,7 @@ const SignIn = () => {
                 placeholder="202875"
                 disabled={disabled}
                 value={pin}
-                maxLength={PASSCODE_MAX_LENGTH}
+                maxLength={PIN_MAX_LENGTH}
                 onChange={(e) => setPin(e.target.value)}
                 onKeyDown={onKeyDown}
                 onPaste={(e) => e.preventDefault()}
@@ -417,10 +417,10 @@ const SignIn = () => {
               Symbol
             </Checkbox>
             <Checkbox id="min-length" value={hasMinLengthPassphrase}>
-              Passphrase length: {PASSWORD_MIN_LENGTH}~{PASSWORD_MAX_LENGTH}
+              Passphrase length: {PASSPHRASE_MIN_LENGTH}~{PASSPHRASE_MAX_LENGTH}
             </Checkbox>
             <Checkbox id="pin-length" value={hasValidPinLength}>
-              PIN length: {PASSCODE_MIN_LENGTH}~{PASSCODE_MAX_LENGTH}
+              PIN length: {PIN_MIN_LENGTH}~{PIN_MAX_LENGTH}
             </Checkbox>
 
             <TermsCheckboxWrapper>

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -336,7 +336,7 @@ const SignIn = () => {
               <Input
                 id="passphrase"
                 type={showPassphrase ? "text" : "password"}
-                placeholder="Passphrase"
+                placeholder="My-1st-car-was-a-red-Ford-2005!"
                 disabled={disabled}
                 value={passphrase}
                 maxLength={PASSWORD_MAX_LENGTH}
@@ -366,7 +366,7 @@ const SignIn = () => {
               <Input
                 id="pin"
                 type={showPin ? "text" : "password"}
-                placeholder="PIN"
+                placeholder="202875"
                 disabled={disabled}
                 value={pin}
                 maxLength={PASSCODE_MAX_LENGTH}


### PR DESCRIPTION
## Summary                                                                                                                                                                                     
Mybucks.online derives wallet private keys from user credentials using Scrypt + Keccak256. There is no reset or recovery — the credentials are the key. The previous field names (password, passcode) failed to communicate this weight to users.

## Why
  - "Password" implies something short, forgettable, and recoverable. "Passphrase" implies a longer, deliberate secret — setting the right expectation for a field that must never be lost.
  - "Passcode" is ambiguous in length and purpose. "PIN" is universally understood as short and numeric-style, making the two fields immediately distinguishable from each other.
  - Together, the pairing passphrase + PIN implicitly teaches users the intended usage pattern without extra documentation.

**No functional changes**. This is a pure rename — no logic, validation, or cryptographic behavior was modified.

## Additional changes: Remove 'self' from 'connect-src' in CSP header
Since mybucks.online is a fully static, browser-only app with no backend under the same origin, 'self' in connect-src was unnecessary. All API calls go to explicitly listed external hosts.
   This tightens the CSP by disallowing any unintended same-origin fetch/XHR connections.