### PR TITLE
Update PIN placeholder to demonstrate stronger entropy

### DIFF
--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -338,7 +338,7 @@ const SignIn = () => {
               <Input
                 id="pin"
                 type={showPin ? "text" : "password"}
-                placeholder="e.g. 202875"
+                placeholder="e.g. 202w875"
                 disabled={disabled}
                 value={pin}
                 maxLength={PIN_MAX_LENGTH}


### PR DESCRIPTION
Changed the PIN input placeholder from `e.g. 202875` to `e.g. 202w875` to encourage users to mix alphanumeric characters in their PIN, better reflecting the expected format and improving the security posture of generated wallets.
