### PR TITLE
Embed commit hash into sign-in page for deployment verification

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -42,6 +42,7 @@ jobs:
           VITE_INFURA_API_KEY: ${{ secrets.VITE_INFURA_API_KEY }}
           VITE_TRONGRID_API_KEY: ${{ secrets.VITE_TRONGRID_API_KEY }}
           VITE_MORALIS_API_KEY: ${{ secrets.VITE_MORALIS_API_KEY }}
+          VITE_COMMIT_HASH: ${{ github.sha }}
         run: yarn build
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -410,6 +410,10 @@ const SignIn = () => {
         </Box>
       </Container>
 
+      {import.meta.env.VITE_COMMIT_HASH && (
+        <SecurityHint data-commit={import.meta.env.VITE_COMMIT_HASH} />
+      )}
+
       <Modal show={!!progress} width="20rem">
         <ProgressWrapper>
           <GreetingIcon src={Logo} alt="Hi" loading="lazy" />


### PR DESCRIPTION
## Summary
- Injects `VITE_COMMIT_HASH` (via `github.sha`) as a build-time env var in the GitHub Actions deploy workflow
- Renders a hidden <p data-commit="..."> element on the sign-in screen so the deployed commit can be confirmed via DevTools without exposing it visibly to users

## How to verify
After deployment, open DevTools on the sign-in page and inspect the DOM for:
```
<p data-commit="<full-sha>"></p>
```

Cross-check the SHA against the corresponding commit on GitHub.
