### PR TITLE
Update CSP to allow TrustedSite scan script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+      content="default-src 'self'; script-src 'self' https://cdn.ywxi.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology https://cdn.ywxi.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
     />
 
     <!-- Canonical URL -->


### PR DESCRIPTION
## Summary:                                                                                                                                                                                    
- Adds **https://cdn.ywxi.net** to **script-src** so the TrustedSite verification script can load                                                                                                   
- Adds https://cdn.ywxi.net to connect-src so the script can make outbound requests for scan/certification data

## Why:                                                                                                                                                                                        
The TrustedSite scan script added in the previous PR was blocked by the existing Content Security Policy, which only allowed scripts and connections from 'self'. Without this change the trustmark badge would silently fail to load in production.

## Test plan:
- Verify no CSP violations appear in the browser console related to cdn.ywxi.net                                                                                                            
- Confirm the TrustedSite badge renders correctly on the live site                                                                                                                          
- Confirm all other existing CSP rules remain intact and no regressions in blocked origins
