### PR TITLE
Fix CSP to allow TrustedSite scan script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://cdn.ywxi.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io; font-src 'self' data:; connect-src https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology https://cdn.ywxi.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+      content="default-src 'self'; script-src 'self'; script-src-elem 'self' https://cdn.ywxi.net; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline' https://cdn.ywxi.net; img-src 'self' data: blob: https://cdn.moralis.io https://logo.moralis.io https://assets.coingecko.com https://beaverbuild.com https://opensea.io https://cdn.ywxi.net; font-src 'self' data:; connect-src https://*.infura.io https://api.trongrid.io https://deep-index.moralis.io https://api.blockchain.info https://bsc-dataseed.binance.org https://gasstation.polygon.technology https://s3-us-west-2.amazonaws.com; frame-src https://www.trustedsite.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
     />
 
     <!-- Canonical URL -->


### PR DESCRIPTION
## Summary:
- Replaces the broad script-src allowance with precise script-src-elem and style-src-elem directives for cdn.ywxi.net                                                                       
- Adds img-src for the trustmark badge, connect-src for TrustedSite's S3 backend, and frame-src for the trustedsite.com iframe

## Changes:
- index.html: Updated CSP with the exact directives provided by TrustedSite

Reference:
https://docs.trustedsite.com/docs/installation/troubleshooting#content-security-policy