### PR TITLE
Fix EVM txn submission on RPCs failing pending nonce lookup

### DIFF
--- a/src/lib/account/evm.js
+++ b/src/lib/account/evm.js
@@ -190,12 +190,22 @@ class EvmAccount {
   }
 
   async execute({ to, data, value = 0, gasPrice = null, gasLimit = null }) {
+    // Some RPC providers fail on "pending" nonce lookups.
+    // Pre-populate nonce from "latest" to avoid ethers fallback path.
+    let nonce = null;
+    try {
+      nonce = await this.provider.getTransactionCount(this.account.address, "latest");
+    } catch (_e) {
+      // Keep null and let ethers resolve nonce using provider defaults.
+    }
+
     const tx = await this.account.sendTransaction({
       to,
       value,
       data,
       gasPrice,
       gasLimit,
+      nonce,
     });
     return await tx.wait();
   }


### PR DESCRIPTION
## Summary
This PR adds a nonce fallback in EVM transaction execution to avoid provider failures on `eth_getTransactionCount(..., "pending")`.
Some RPC endpoints return an internal error for the `"pending"` block tag during transaction submission. Since ethers may use this path internally, transaction confirmation could fail before broadcast.
To improve compatibility, we now prefetch nonce with "latest" and pass it explicitly to sendTransaction.

