### PR TITLE
Show gas fee estimate even when rounded to 0

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,9 @@
       content="seedless wallet, gifting wallet, gift wallet, burner wallet, p2p gifting, disposable crypto wallet, 1-click gifting, browser-based wallet, crypto airdrop, marketing campaigns, instant onboarding, no seed phrase wallet, self-custodial wallet, crypto gift, airdrop wallet, disposable wallet, temporary wallet, crypto URL wallet, Layer3 rewards, crypto marketing, Ethereum wallet, arbitrum, optimism, bnb chain, polygon, avalanche, tron, usdt, decentralized wallet, online wallet, mybucks, mybucks.online"
     />
 
-    <title>Mybucks.online | Seedless, Disposable Crypto Wallet with 1-Click Gifting</title>
+    <title>
+      Mybucks.online | Seedless, Disposable Crypto Wallet with 1-Click Gifting
+    </title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/network/evm/Token.jsx
+++ b/src/pages/network/evm/Token.jsx
@@ -334,7 +334,7 @@ const Token = () => {
             <img src={InfoRedIcon} />
             <span>Invalid transfer</span>
           </InvalidTransfer>
-        ) : gasEstimation > 0 ? (
+        ) : gasEstimationValue > 0 ? (
           <EstimatedGasFee>
             <img src={InfoGreenIcon} />
             <span>


### PR DESCRIPTION
On the token transfer screen, gas fee estimation visibility was checked against the wrong unit.
`gasEstimation` represents native token amount (e.g., ETH), while `gasEstimationValue` represents `USD`.

This PR updates the condition to validate using `gasEstimationValue` > 0 (USD) so the gas estimate section is shown based on the intended USD value check.