### PR TITLE
Add EVM token whitelist for balance display

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybucks-online",
   "description": "Web app for Mybucks.online — a seedless wallet and gifting wallet: disposable gift wallets, fund and share via secure 1-click URL. Browser-only (no servers, database, or install). For airdrops, giveaways, campaigns, and instant onboarding.",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "keywords": [
     "mybucks",

--- a/src/lib/account/evm.js
+++ b/src/lib/account/evm.js
@@ -4,6 +4,7 @@ import { Contract, ethers } from "ethers";
 
 import { EVM_NETWORKS, NETWORK } from "@mybucks/lib/conf";
 import IERC20 from "@mybucks/lib/erc20.json";
+import { isWhitelistedToken } from "@mybucks/lib/tokenWhitelist";
 import {
   getErc20TokenHistory,
   getNativeAndErc20TokenBalances,
@@ -68,9 +69,14 @@ class EvmAccount {
         const isNative = token.native_token || false;
         if (isNative) return true;
 
-        return defaultTokensList.find(
-          ({ address }) =>
-            address.toLowerCase() === token.token_address.toLowerCase(),
+        const tokenAddress = token.token_address;
+        return (
+          isWhitelistedToken(this.chainId, tokenAddress) ||
+          defaultTokensList.some(
+            ({ address, chainId }) =>
+              chainId === this.chainId &&
+              address.toLowerCase() === tokenAddress.toLowerCase(),
+          )
         );
       })
       .map((token) => {

--- a/src/lib/tokenWhitelist.js
+++ b/src/lib/tokenWhitelist.js
@@ -1,0 +1,25 @@
+import whitelists from "@mybucks/lib/whitelists.json";
+import { EVM_NETWORKS } from "@mybucks/lib/conf";
+
+const networkNameToChainId = Object.fromEntries(
+  EVM_NETWORKS.map((n) => [n.name, n.chainId]),
+);
+
+const whitelistKeys = new Set(
+  whitelists
+    .map((entry) => {
+      const chainId = entry.chainId ?? networkNameToChainId[entry.network];
+      if (!chainId || !entry.address) {
+        return null;
+      }
+      return `${chainId}:${entry.address.toLowerCase()}`;
+    })
+    .filter(Boolean),
+);
+
+export function isWhitelistedToken(chainId, tokenAddress) {
+  if (!tokenAddress) {
+    return false;
+  }
+  return whitelistKeys.has(`${chainId}:${tokenAddress.toLowerCase()}`);
+}

--- a/src/lib/whitelists.json
+++ b/src/lib/whitelists.json
@@ -1,0 +1,6 @@
+[
+  {
+    "address": "0xA3f751662e282E83EC3cBc387d225Ca56dD63D3A",
+    "network": "polygon"
+  }
+]


### PR DESCRIPTION
Balances from Moralis were only shown for tokens on the Uniswap default list.
Some holdings (e.g. APEPE on Polygon) are omitted from that list.

- Add src/lib/whitelists.json for extra { address, network } entries
- Add src/lib/tokenWhitelist.js to resolve whitelist by chain
- Update queryBalances() in evm.js to include whitelisted tokens and match Uniswap tokens by chainId + address (not address alone)

Initial whitelist: APEPE (0xA3f751662e282E83EC3cBc387d225Ca56dD63D3A) on Polygon.

<img width="868" height="738" alt="image" src="https://github.com/user-attachments/assets/02ff0480-f7b0-457a-830f-cb619456de9a" />
