### PR TITLE
Upgrades @uniswap/default-token-list from 13.5.0 to 22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@mybucks.online/core": "^3.0.4",
-    "@uniswap/default-token-list": "^13.5.0",
+    "@uniswap/default-token-list": "^22.0.0",
     "buffer": "^6.0.3",
     "clipboard-copy": "^4.0.1",
     "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybucks-online",
   "description": "Web app for Mybucks.online — a seedless wallet and gifting wallet: disposable gift wallets, fund and share via secure 1-click URL. Browser-only (no servers, database, or install). For airdrops, giveaways, campaigns, and instant onboarding.",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "keywords": [
     "mybucks",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,10 +1925,10 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
-"@uniswap/default-token-list@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.npmjs.org/@uniswap/default-token-list/-/default-token-list-13.5.0.tgz"
-  integrity sha512-VDCOWxj7ZTYv2r750KeNTbBMyou1RzgIt+/AXWc4FgVIuOQyqsVZulfaEANLE+6smYEHdkuUpQid/5EdDNHM8A==
+"@uniswap/default-token-list@^22.0.0":
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-22.0.0.tgz#e8415b28baf2b746f4ce213775d68e733b9cf7dd"
+  integrity sha512-3OwWWsd7Wo1HEIxVLcK6dL628zRdc/Hfjcc7sbel1ioySQ+dtVbANkmf7+d6KrWroE5p1fcEimKlYAQ1se96Mg==
 
 "@vitejs/plugin-react@^4.2.1":
   version "4.3.0"


### PR DESCRIPTION
## Summary
Upgrades **@uniswap/default-token-list** from **13.5.0** to **22.0.0** so the app uses Uniswap’s current default token list for balance filtering.

## Why
The app only surfaces ERC-20 balances that Moralis returns and that pass either whitelists.json or the Uniswap default list (evm.js). The old list (13.5.0) had no Monad (chainId: 143) entries, so Monad tokens were invisible unless manually whitelisted.

**22.0.0** adds Monad and other newer chains Uniswap supports in its interface.