### PR TITLE
Allow TRC20 transfers to inactive Tron addresses, update Passphrase placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybucks-online",
   "description": "Mybucks.online wallet app — a digital cash envelope for crypto gifting: create or claim a seedless, disposable crypto wallet, fund it, and share a 1-click URL. Browser-only (no servers, database, or install).",
   "private": true,
-  "version": "2.5.2",
+  "version": "2.5.3",
   "type": "module",
   "keywords": [
     "mybucks",

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -363,7 +363,7 @@ const SignIn = () => {
             <CompactInput
               id="passphrase"
               type={showPassphrase ? "text" : "password"}
-              placeholder="e.g. My-1st-car-was-a-red-Ford-2005!"
+              placeholder="e.g. kQGe-oTFY-m/1*-Jmhq"
               disabled={disabled}
               value={passphrase}
               maxLength={PASSPHRASE_MAX_LENGTH}

--- a/src/pages/network/tron/Token.jsx
+++ b/src/pages/network/tron/Token.jsx
@@ -207,11 +207,6 @@ const Token = () => {
     try {
       const isActivated = await account.isActivated(recipient);
       setRecipientActivated(isActivated);
-      // trc20 can't be transferred to inactivated account
-      if (!token.native && !isActivated) {
-        setHasErrorInput(true);
-        return;
-      }
 
       const txData = await account.populateTransferToken(
         token.native ? "" : selectedTokenAddress,
@@ -342,16 +337,19 @@ const Token = () => {
           <MaxButton onClick={() => setAmount(token.balance)}>Max</MaxButton>
         </AmountWrapper>
 
-        {invalidRecipientAddress ? (
+        {invalidRecipientAddress && (
           <InvalidTransfer>
             <img src={InfoRedIcon} />
             <span>Invalid address</span>
           </InvalidTransfer>
-        ) : !recipientActivated && !token.native ? (
+        )}
+
+        {!invalidRecipientAddress && !recipientActivated && !token.native && (
           <InvalidTransfer>
             <img src={InfoRedIcon} />
             <span>
-              Recipient is not activated.{" "}
+              Recipient is not activated. You will be charged account creation
+              fee.{" "}
               <ErrorRefLink
                 href="https://developers.tron.network/docs/account#account-activation"
                 target="_blank"
@@ -360,22 +358,23 @@ const Token = () => {
               </ErrorRefLink>
             </span>
           </InvalidTransfer>
-        ) : hasErrorInput ? (
-          <InvalidTransfer>
-            <img src={InfoRedIcon} />
-            <span>Invalid transfer</span>
-          </InvalidTransfer>
-        ) : bandwidthEstimation || energyEstimation ? (
-          <EstimatedGasFee>
-            <img src={InfoGreenIcon} />
-            <span>
-              Estimated consumption: {bandwidthEstimation} Bandwidth{" "}
-              {energyEstimation > 0 ? `+ ${energyEstimation} Energy` : ""}
-            </span>
-          </EstimatedGasFee>
-        ) : (
-          <></>
         )}
+
+        {!invalidRecipientAddress &&
+          (hasErrorInput ? (
+            <InvalidTransfer>
+              <img src={InfoRedIcon} />
+              <span>Invalid transfer</span>
+            </InvalidTransfer>
+          ) : bandwidthEstimation || energyEstimation ? (
+            <EstimatedGasFee>
+              <img src={InfoGreenIcon} />
+              <span>
+                Estimated consumption: {bandwidthEstimation} Bandwidth{" "}
+                {energyEstimation > 0 ? `+ ${energyEstimation} Energy` : ""}
+              </span>
+            </EstimatedGasFee>
+          ) : null)}
 
         <Submit
           onClick={() => setConfirming(true)}

--- a/src/pages/network/tron/Token.jsx
+++ b/src/pages/network/tron/Token.jsx
@@ -126,22 +126,28 @@ const InvalidTransfer = styled.div`
   border-radius: ${({ theme }) => theme.sizes.x3s};
   color: ${({ theme }) => theme.colors.error};
   border: 1px solid ${({ theme }) => theme.colors.error};
-  margin-bottom: ${({ theme }) => theme.sizes.x2l};
   font-weight: ${({ theme }) => theme.weights.base};
   font-size: ${({ theme }) => theme.sizes.xs};
   line-height: 180%;
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.sizes.x2s};
-
-  ${media.sm`
-    margin-bottom: ${({ theme }) => theme.sizes.xl};
-  `}
 `;
 
 const EstimatedGasFee = styled(InvalidTransfer)`
   color: ${({ theme }) => theme.colors.success};
   border: 1px solid ${({ theme }) => theme.colors.success};
+`;
+
+const Alerts = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.sizes.x2s};
+  margin-bottom: ${({ theme }) => theme.sizes.x2l};
+
+  ${media.sm`
+    margin-bottom: ${({ theme }) => theme.sizes.xl};
+  `}
 `;
 
 const Submit = styled(Button)`
@@ -266,6 +272,19 @@ const Token = () => {
     );
   }
 
+  const showInactiveWarning =
+    !invalidRecipientAddress && !recipientActivated && !token.native;
+  const showGasEstimate =
+    !invalidRecipientAddress &&
+    !hasErrorInput &&
+    (bandwidthEstimation > 0 || energyEstimation > 0);
+  const showInvalidTransfer = !invalidRecipientAddress && hasErrorInput;
+  const hasAlerts =
+    invalidRecipientAddress ||
+    showInactiveWarning ||
+    showInvalidTransfer ||
+    showGasEstimate;
+
   return (
     <TokenLayout>
       <NavsWrapper>
@@ -337,44 +356,49 @@ const Token = () => {
           <MaxButton onClick={() => setAmount(token.balance)}>Max</MaxButton>
         </AmountWrapper>
 
-        {invalidRecipientAddress && (
-          <InvalidTransfer>
-            <img src={InfoRedIcon} />
-            <span>Invalid address</span>
-          </InvalidTransfer>
-        )}
+        {hasAlerts && (
+          <Alerts>
+            {invalidRecipientAddress && (
+              <InvalidTransfer>
+                <img src={InfoRedIcon} />
+                <span>Invalid address</span>
+              </InvalidTransfer>
+            )}
 
-        {!invalidRecipientAddress && !recipientActivated && !token.native && (
-          <InvalidTransfer>
-            <img src={InfoRedIcon} />
-            <span>
-              Recipient is not activated. You will be charged account creation
-              fee.{" "}
-              <ErrorRefLink
-                href="https://developers.tron.network/docs/account#account-activation"
-                target="_blank"
-              >
-                Learn More.
-              </ErrorRefLink>
-            </span>
-          </InvalidTransfer>
-        )}
+            {showInactiveWarning && (
+              <InvalidTransfer>
+                <img src={InfoRedIcon} />
+                <span>
+                  Recipient is not activated. You will be charged account
+                  creation fee.{" "}
+                  <ErrorRefLink
+                    href="https://developers.tron.network/docs/account#account-activation"
+                    target="_blank"
+                  >
+                    Learn More.
+                  </ErrorRefLink>
+                </span>
+              </InvalidTransfer>
+            )}
 
-        {!invalidRecipientAddress &&
-          (hasErrorInput ? (
-            <InvalidTransfer>
-              <img src={InfoRedIcon} />
-              <span>Invalid transfer</span>
-            </InvalidTransfer>
-          ) : bandwidthEstimation || energyEstimation ? (
-            <EstimatedGasFee>
-              <img src={InfoGreenIcon} />
-              <span>
-                Estimated consumption: {bandwidthEstimation} Bandwidth{" "}
-                {energyEstimation > 0 ? `+ ${energyEstimation} Energy` : ""}
-              </span>
-            </EstimatedGasFee>
-          ) : null)}
+            {showInvalidTransfer && (
+              <InvalidTransfer>
+                <img src={InfoRedIcon} />
+                <span>Invalid transfer</span>
+              </InvalidTransfer>
+            )}
+
+            {showGasEstimate && (
+              <EstimatedGasFee>
+                <img src={InfoGreenIcon} />
+                <span>
+                  Estimated consumption: {bandwidthEstimation} Bandwidth{" "}
+                  {energyEstimation > 0 ? `+ ${energyEstimation} Energy` : ""}
+                </span>
+              </EstimatedGasFee>
+            )}
+          </Alerts>
+        )}
 
         <Submit
           onClick={() => setConfirming(true)}


### PR DESCRIPTION
## Summary
- update passphrase placeholder in create screen
- Remove the block that prevented TRC20 sends to unactivated recipients
- Show a non-blocking warning about account creation fees instead
- Allow gas estimates to display alongside the inactive-recipient warning