### PR TITLE
Remove legacy wallet checkbox from sign-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybucks-online",
   "description": "Mybucks.online wallet app — a digital cash envelope for crypto gifting: create or claim a seedless, disposable crypto wallet, fund it, and share a 1-click URL. Browser-only (no servers, database, or install).",
   "private": true,
-  "version": "2.5.4",
+  "version": "2.6.0",
   "type": "module",
   "keywords": [
     "mybucks",

--- a/src/pages/Signin/index.jsx
+++ b/src/pages/Signin/index.jsx
@@ -164,34 +164,6 @@ const SigninLegalSection = styled.div`
   width: 100%;
 `;
 
-const LegacyWalletCheckboxWrapper = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: ${({ theme }) => theme.sizes.xs};
-
-  input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
-    margin-top: 0.2rem;
-    flex-shrink: 0;
-    accent-color: ${({ theme }) => theme.colors.primary};
-    cursor: pointer;
-  }
-
-  label {
-    font-size: ${({ theme }) => theme.fontSize.sm};
-    font-weight: ${({ theme }) => theme.weights.regular};
-    color: ${({ theme }) => theme.colors.textMuted};
-    cursor: pointer;
-    user-select: none;
-    line-height: 1.45;
-  }
-
-  a {
-    font-size: inherit;
-  }
-`;
-
 const TermsNotice = styled.p`
   text-align: left;
   font-size: ${({ theme }) => theme.fontSize.sm};
@@ -240,7 +212,6 @@ const SignIn = () => {
   const [showPin, setShowPin] = useState(false);
   const [passphraseFocused, setPassphraseFocused] = useState(false);
   const [pinFocused, setPinFocused] = useState(false);
-  const [legacySelected, setLegacySelected] = useState(false);
 
   const passphraseStrength = useMemo(() => {
     if (!passphrase) return 0;
@@ -298,7 +269,6 @@ const SignIn = () => {
 
       // open wallet
       setDisabled(true);
-      setLegacySelected(lgcy);
       const hash = await generateHash(
         pphrase,
         pn,
@@ -319,9 +289,9 @@ const SignIn = () => {
       passphrase,
       pin,
       (p) => setProgress(Math.floor(p * 100)),
-      legacySelected,
+      false,
     );
-    setup(passphrase, pin, legacySelected, hash);
+    setup(passphrase, pin, false, hash);
     setDisabled(false);
   };
 
@@ -434,27 +404,6 @@ const SignIn = () => {
         </div>
 
         <SigninLegalSection>
-          <LegacyWalletCheckboxWrapper>
-            <input
-              type="checkbox"
-              id="legacy-wallet"
-              checked={legacySelected}
-              onChange={(e) => setLegacySelected(e.target.checked)}
-              disabled={disabled}
-            />
-            <label htmlFor="legacy-wallet">
-              This wallet was created before March 2026.{" "}
-              <Link
-                href="https://docs.mybucks.online/concept/march-2026-security-update"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                Learn more
-              </Link>
-            </label>
-          </LegacyWalletCheckboxWrapper>
-
           <TermsNotice>
             By clicking Open, you agree to our{" "}
             <Link

--- a/src/styles/themes.js
+++ b/src/styles/themes.js
@@ -24,7 +24,7 @@ const sizes = {
   x4l: "2.5rem",
   shellMax: "72rem",
   cardMaxWidth: "40rem",
-  cardMinHeight: "40rem",
+  cardMinHeight: "36rem",
   cardMinHeightLg: "32rem",
   viewportShort: "720px",
   viewportShorter: "560px",


### PR DESCRIPTION
## Summary
- Remove the “**legacy wallet**” checkbox from the sign-in form
- Manual sign-in **always** uses the **default** key derivation
- Wallet links still honor the legacy flag from parseToken

